### PR TITLE
dirty fix for changing CreateVenuespeopleTable => CreateVenuesPeopleTabl...

### DIFF
--- a/src/Raahul/LarryFour/Generator/MigrationGenerator.php
+++ b/src/Raahul/LarryFour/Generator/MigrationGenerator.php
@@ -188,8 +188,9 @@ class MigrationGenerator
      */
     private function addClassName($migrationContent, $tableName)
     {
+        $className = str_replace('_', ' ', $tableName);
         // Class name is the name of the table uppercased and without underscores
-        $className = 'Create' . ucwords($tableName) . 'Table';
+        $className = 'Create' . ucwords($className) . 'Table';
         $className = str_replace('_', '', $className);
 
         return str_replace('{{className}}', $className, $migrationContent);


### PR DESCRIPTION
I have custom table "venues_people", and the migration class created is "CreateVenuespeopleTable", instead of "CreateVenuesPeopleTable", causing the artisan migrate:rollback to fail finding the class

I'm sure there are better ways to do this. This is just a dirty fix.
